### PR TITLE
Fix remote image build failure

### DIFF
--- a/src/components/OptimizedPicture.astro
+++ b/src/components/OptimizedPicture.astro
@@ -25,17 +25,31 @@ const {
   loading = "lazy",
   fetchpriority = "auto",
 } = Astro.props;
+
+const isRemote = src.startsWith("http://") || src.startsWith("https://");
 ---
 
-<Picture
-  src={src}
-  alt={alt}
-  widths={widths}
-  sizes={sizes}
-  formats={["avif"]}
-  fallbackFormat="avif"
-  class={className}
-  loading={loading}
-  fetchpriority={fetchpriority}
-  inferSize
-/>
+{
+  isRemote ? (
+    <img
+      src={src}
+      alt={alt}
+      class={className}
+      loading={loading}
+      fetchpriority={fetchpriority}
+    />
+  ) : (
+    <Picture
+      src={src}
+      alt={alt}
+      widths={widths}
+      sizes={sizes}
+      formats={["avif"]}
+      fallbackFormat="avif"
+      class={className}
+      loading={loading}
+      fetchpriority={fetchpriority}
+      inferSize
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- detect remote image URLs
- render `<img>` for remote sources instead of `Picture`

## Testing
- `pnpm run build`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_685417788b1083338cf2708dd4f07a26